### PR TITLE
*: add ppc64le

### DIFF
--- a/native_bigendian.go
+++ b/native_bigendian.go
@@ -1,4 +1,4 @@
-// +build armbe arm64be ppc64 mips mips64 mips64p32 ppc sparc sparc64 s390 s390x
+// +build armbe arm64be mips mips64 mips64p32 ppc ppc64 sparc sparc64 s390 s390x
 
 package native_endian
 

--- a/native_littleendian.go
+++ b/native_littleendian.go
@@ -1,4 +1,4 @@
-// +build 386 amd64 amd64p32 arm arm64 mipsle mis64le mips64p32le riscv riscv64 wasm
+// +build 386 amd64 amd64p32 arm arm64 mipsle mis64le mips64p32le ppc64le riscv riscv64 wasm
 
 package native_endian
 


### PR DESCRIPTION
ppc64le was missing from the set of little endian arches.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>